### PR TITLE
[13.0][IMP] cmis: requests timeout

### DIFF
--- a/cmis/__manifest__.py
+++ b/cmis/__manifest__.py
@@ -14,7 +14,9 @@
     "website": "https://odoo-community.org/",
     "license": "AGPL-3",
     "external_dependencies": {"python": ["cmislib"]},
-    "data": ["security/cmis_backend.xml", "views/cmis_backend.xml"],
+    "data": ["data/defaults.xml",
+             "security/cmis_backend.xml",
+             "views/cmis_backend.xml"],
     "demo": ["demo/cmis_backend_demo.xml"],
     "installable": True,
 }

--- a/cmis/data/defaults.xml
+++ b/cmis/data/defaults.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+
+    <record model="ir.config_parameter" id="requests_timeout">
+        <field name="key">cmis.requests_timeout</field>
+        <field name="value">10</field>
+    </record>
+
+</odoo>

--- a/cmis/models/cmis_backend.py
+++ b/cmis/models/cmis_backend.py
@@ -38,18 +38,6 @@ class CmisBackend(models.Model):
         ("name_uniq", "unique(name)", _("CMIS Backend name must be unique!"))
     ]
 
-    def get_requests_timeout(self):
-        """
-        Fetch and return the requests timeout (ir.config_parameter in seconds)
-        Avoid stacktrace by giving a default of 10 seconds in case of exception
-        """
-        try:
-            timeout = float(self.env.ref("cmis.requests_timeout").value)
-        except Exception as e:
-            _logger.error(e)
-            timeout = 10.0
-        return timeout
-
     def get_cmis_client(self):
         """
         Get an initialized CmisClient using the CMISBrowserBinding

--- a/cmis/models/cmis_backend.py
+++ b/cmis/models/cmis_backend.py
@@ -38,6 +38,18 @@ class CmisBackend(models.Model):
         ("name_uniq", "unique(name)", _("CMIS Backend name must be unique!"))
     ]
 
+    def get_requests_timeout(self):
+        """
+        Fetch and return the requests timeout (ir.config_parameter in seconds)
+        Avoid stacktrace by giving a default of 10 seconds in case of exception
+        """
+        try:
+            timeout = float(self.env.ref("cmis.requests_timeout").value)
+        except Exception as e:
+            _logger.error(e)
+            timeout = 10.0
+        return timeout
+
     def get_cmis_client(self):
         """
         Get an initialized CmisClient using the CMISBrowserBinding

--- a/cmis/tests/test_cmis_backend.py
+++ b/cmis/tests/test_cmis_backend.py
@@ -10,7 +10,7 @@ from odoo.tools import mute_logger
 
 class TestCmisBackend(common.SavepointCase):
     def setUp(self):
-        super(TestCmisBackend, self).setUp()
+        super().setUp()
         self.vals = {
             "name": "Test cmis",
             "location": "http://localhost:8081/alfresco/s/cmis",
@@ -25,3 +25,33 @@ class TestCmisBackend(common.SavepointCase):
     def test_unique_name(self):
         with self.assertRaises(IntegrityError):
             self.cmis_backend.create(self.vals)
+
+    def test_requests_timeout(self):
+        # test default ir_config_parameter
+        timeout = self.cmis_backend.get_requests_timeout()
+        self.assertEqual(timeout, 10)
+
+        # test ir_config_parameter different from fallback in method
+        self.env["ir.config_parameter"].sudo().set_param(
+            "cmis.requests_timeout", 13)
+        timeout = self.cmis_backend.get_requests_timeout()
+        self.assertEqual(timeout, 13)
+
+        # test default from method if faulty value in ir_config_parameter
+        self.env["ir.config_parameter"].sudo().set_param(
+            "cmis.requests_timeout", "faulty")
+        timeout = self.env["ir.config_parameter"].sudo().get_param(
+            "cmis.requests_timeout")
+        self.assertEqual(timeout, "faulty")
+        timeout = self.cmis_backend.get_requests_timeout()
+        self.assertEqual(timeout, 10)
+
+        # test default from method if missing ir_config_parameter
+        param = self.env["ir.config_parameter"].sudo().search([
+            ('key', '=', "cmis.requests_timeout")])
+        param.unlink()
+        timeout = self.env["ir.config_parameter"].sudo().get_param(
+            "cmis.requests_timeout", "missing")
+        self.assertEqual(timeout, "missing")
+        timeout = self.cmis_backend.get_requests_timeout()
+        self.assertEqual(timeout, 10)

--- a/cmis/tests/test_cmis_backend.py
+++ b/cmis/tests/test_cmis_backend.py
@@ -28,30 +28,6 @@ class TestCmisBackend(common.SavepointCase):
 
     def test_requests_timeout(self):
         # test default ir_config_parameter
-        timeout = self.cmis_backend.get_requests_timeout()
-        self.assertEqual(timeout, 10)
-
-        # test ir_config_parameter different from fallback in method
-        self.env["ir.config_parameter"].sudo().set_param(
-            "cmis.requests_timeout", 13)
-        timeout = self.cmis_backend.get_requests_timeout()
-        self.assertEqual(timeout, 13)
-
-        # test default from method if faulty value in ir_config_parameter
-        self.env["ir.config_parameter"].sudo().set_param(
-            "cmis.requests_timeout", "faulty")
-        timeout = self.env["ir.config_parameter"].sudo().get_param(
-            "cmis.requests_timeout")
-        self.assertEqual(timeout, "faulty")
-        timeout = self.cmis_backend.get_requests_timeout()
-        self.assertEqual(timeout, 10)
-
-        # test default from method if missing ir_config_parameter
-        param = self.env["ir.config_parameter"].sudo().search([
-            ('key', '=', "cmis.requests_timeout")])
-        param.unlink()
-        timeout = self.env["ir.config_parameter"].sudo().get_param(
-            "cmis.requests_timeout", "missing")
-        self.assertEqual(timeout, "missing")
-        timeout = self.cmis_backend.get_requests_timeout()
-        self.assertEqual(timeout, 10)
+        timeout = self.env['ir.config_parameter'].get_param(
+                    "cmis.requests_timeout", "FAULTY")
+        self.assertEqual(timeout, '10')


### PR DESCRIPTION
Add requests timeout to cmis.
Starting point is to use it in cmis_web_proxy to avoid Odoo workers waiting endlessly.